### PR TITLE
fix(fzf): drop --height so pickers use the alternate screen

### DIFF
--- a/bin/ghf
+++ b/bin/ghf
@@ -174,7 +174,6 @@ _show_main_menu() {
       --ghost='select a module | Enter (navigate) | Esc (exit)' \
       --header=$'>> GitHub Fuzzy - Interactive GitHub CLI <<\n' \
       --preview-window=hidden \
-      --height=~50% \
       --bind="enter:become(
         case '{1}' in
           '[notif]'*) source $SCRIPT_FILE && _browse_notifications ;;

--- a/zshrc
+++ b/zshrc
@@ -40,7 +40,7 @@ _load_settings "$XDG_CONFIG_HOME/zsh/configs"
 source "$XDG_CONFIG_HOME/zsh/plugins/zsh-syntax-highlighting.zsh"
 
 if [[ -f ~/.fzf.zsh ]]; then
-  export FZF_DEFAULT_OPTS_PARTIAL=" --inline-info --separator='' --marker '+' --scrollbar '' --preview 'cat {}' --preview-window=hidden --bind 'ctrl-p:toggle-preview,ctrl-u:preview-half-page-up,ctrl-d:preview-half-page-down' --height 100% --gutter=' ' --color gutter:-1"
+  export FZF_DEFAULT_OPTS_PARTIAL=" --inline-info --separator='' --marker '+' --scrollbar '' --preview 'cat {}' --preview-window=hidden --bind 'ctrl-p:toggle-preview,ctrl-u:preview-half-page-up,ctrl-d:preview-half-page-down' --gutter=' ' --color gutter:-1"
   export FZF_DEFAULT_OPTS=" $FZF_DEFAULT_OPTS_PARTIAL \
     --color=fg:-1,bg:-1,fg+:green,bg+:-1 \
     --color=hl:cyan,hl+:cyan \


### PR DESCRIPTION
Global FZF_DEFAULT_OPTS carried --height 100%, so every fzf picker ran in
the normal buffer (no alternate screen) and managed the scroll region
manually. After fzf `execute` children such as kfc's `kubectl logs -f`,
or after frequent terminal resizes, that scroll region / cursor state was
never reset, leaving the terminal clobbered (misplaced prompt, banded
output, broken wrapping).

Remove --height in both places (zshrc FZF_DEFAULT_OPTS_PARTIAL and ghf's
main menu) so all pickers use the alternate screen buffer, which saves and
restores the terminal cleanly. kfc and the gfc git widgets inherit the
global opts and need no further change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016RLBxjdpooQoY2q9hrN5LS